### PR TITLE
Rollback to reset class without :where

### DIFF
--- a/backend-clapy/export-templates/resets.module.css
+++ b/backend-clapy/export-templates/resets.module.css
@@ -1,4 +1,4 @@
-:where(.clapyResets), :where(.clapyResets) * {
+.clapyResets, .clapyResets * {
   display: flex;
   box-sizing: border-box;
   margin: 0;


### PR DESCRIPTION
I take the risk of specificity issues, but it seems it's imported in the right order. We will see.
:where is KO in codesandbox.